### PR TITLE
feat: add market stats to collection & ecosystem endpoints

### DIFF
--- a/apps/api/.prettierrc
+++ b/apps/api/.prettierrc
@@ -1,0 +1,16 @@
+{
+  "printWidth": 160,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "jsxBracketSameLine": false,
+  "trailingComma": "none",
+  "requirePragma": false,
+  "insertPragma": false,
+  "singleQuote": false,
+  "arrowParens": "always",
+  "endOfLine": "crlf",
+  "htmlWhitespaceSensitivity": "strict"
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "@hono/zod-openapi": "^0.14.4",
     "axios": "^1.6.8",
     "database": "workspace:*",
+    "date-fns": "^3.6.0",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.32.0",
     "hono": "^4.1.7",

--- a/apps/api/src/routes/v1/ecosystems/ecosystems.ts
+++ b/apps/api/src/routes/v1/ecosystems/ecosystems.ts
@@ -33,24 +33,48 @@ const route = createRoute({
                     royaltyFee: z.string(),
                     maxNumToken: z.number().nullable(),
                     perAddressLimit: z.number().nullable(),
-                    startTime: z.string(),
-                    unitPrice: z.number().nullable(),
+                    startTime: z.string().nullable(),
+                    unitPrice: z.string().nullable(),
                     unitDenom: z.string().nullable(),
+                    nftCount: z.number(),
+                    uniqueOwnerCount: z.number(),
+                    floorPrice: z.string().nullable(),
+                    saleCount: z.number(),
+                    saleVolume: z.object({
+                      upasg: z.string().nullable(),
+                      usd: z.string().nullable()
+                    }),
+                    saleCount24hAgo: z.number(),
+                    saleVolume24hAgo: z.object({
+                      upasg: z.string().nullable(),
+                      usd: z.string().nullable()
+                    }),
+                    saleCount7dAgo: z.number(),
+                    saleVolume7dAgo: z.object({
+                      upasg: z.string().nullable(),
+                      usd: z.string().nullable()
+                    }),
+                    saleCount30dAgo: z.number(),
+                    saleVolume30dAgo: z.object({
+                      upasg: z.string().nullable(),
+                      usd: z.string().nullable()
+                    }),
+                    listedTokenCount: z.number()
                   })
-                ),
+                )
               })
-            ),
-          }),
-        },
-      },
-    },
-  },
+            )
+          })
+        }
+      }
+    }
+  }
 });
 
 export default new OpenAPIHono().openapi(route, async (c) => {
   const ecosystems = await getEcosystems();
 
   return c.json({
-    ecosystems,
+    ecosystems
   });
 });

--- a/apps/api/src/services/collection.service.ts
+++ b/apps/api/src/services/collection.service.ts
@@ -1,0 +1,86 @@
+import { block, day, db, eq, nft, nftListing, nftSale, and, lte, min, sql, sum, count, countDistinct } from "database";
+import { subHours, subDays } from "date-fns";
+
+export async function getCollectionStats(collectionAddress: string) {
+  const [
+    nftCount,
+    uniqueOwnerCount,
+    floorPrice,
+    { saleCount, saleVolume },
+    { saleCount: saleCount24hAgo, saleVolume: saleVolume24hAgo },
+    { saleCount: saleCount7dAgo, saleVolume: saleVolume7dAgo },
+    { saleCount: saleCount30dAgo, saleVolume: saleVolume30dAgo },
+    listedTokenCount
+  ] = await Promise.all([
+    getNftCount(collectionAddress),
+    getUniqueOwnerCount(collectionAddress),
+    getFloorPrice(collectionAddress),
+    getSaleAndVolumeAtDate(collectionAddress),
+    getSaleAndVolumeAtDate(collectionAddress, subHours(new Date(), 24)),
+    getSaleAndVolumeAtDate(collectionAddress, subDays(new Date(), 7)),
+    getSaleAndVolumeAtDate(collectionAddress, subDays(new Date(), 30)),
+    getListedTokenCount(collectionAddress)
+  ]);
+
+  return {
+    nftCount,
+    uniqueOwnerCount,
+    floorPrice,
+    saleCount,
+    saleVolume,
+    saleCount24hAgo,
+    saleVolume24hAgo,
+    saleCount7dAgo,
+    saleVolume7dAgo,
+    saleCount30dAgo,
+    saleVolume30dAgo,
+    listedTokenCount
+  };
+}
+
+async function getFloorPrice(collectionAddress: string) {
+  const [{ floorPrice }] = await db
+    .select({ floorPrice: min(nftListing.forSalePrice) })
+    .from(nftListing)
+    .innerJoin(nft, eq(nftListing.nft, nft.id))
+    .where(eq(nft.collection, collectionAddress));
+
+  return floorPrice;
+}
+
+async function getNftCount(collectionAddress: string) {
+  const [{ nftCount }] = await db.select({ nftCount: count() }).from(nft).where(eq(nft.collection, collectionAddress));
+
+  return nftCount;
+}
+
+async function getListedTokenCount(collectionAddress: string) {
+  const [{ listedTokenCount }] = await db
+    .select({ listedTokenCount: count() })
+    .from(nftListing)
+    .innerJoin(nft, eq(nftListing.nft, nft.id))
+    .where(eq(nft.collection, collectionAddress));
+
+  return listedTokenCount;
+}
+
+async function getUniqueOwnerCount(collectionAddress: string) {
+  const [{ uniqueOwnerCount }] = await db
+    .select({ uniqueOwnerCount: countDistinct(nft.owner) })
+    .from(nft)
+    .where(eq(nft.collection, collectionAddress));
+
+  return uniqueOwnerCount;
+}
+
+async function getSaleAndVolumeAtDate(collectionAddress: string, date?: Date) {
+  const [{ saleCount, saleVolumeUPasg, saleVolumeUSD }] = await db
+    .select({ saleCount: count(), saleVolumeUPasg: sum(nftSale.salePrice), saleVolumeUSD: sum(sql`${nftSale.salePrice} * ${day.tokenPrice} / 1000000`) })
+    .from(nftSale)
+    .innerJoin(nft, eq(nftSale.nft, nft.id))
+    .innerJoin(block, eq(nftSale.saleBlockHeight, block.height))
+    .innerJoin(day, eq(block.dayId, day.id))
+    .where(and(eq(nft.collection, collectionAddress), lte(block.datetime, date).if(date)));
+
+  return { saleCount, saleVolume: { upasg: saleVolumeUPasg, usd: saleVolumeUSD } };
+}

--- a/apps/api/src/utils/collection.util.ts
+++ b/apps/api/src/utils/collection.util.ts
@@ -1,22 +1,28 @@
+import { getCollectionStats } from "@src/services/collection.service";
 import { Collection } from "database";
 
-export const mapCollection = (collection: Collection) => ({
-  address: collection.address,
-  createdHeight: collection.createdHeight,
-  name: collection.name,
-  symbol: collection.symbol,
-  mintContract: collection.mintContract,
-  marketContract: collection.marketContract,
-  minter: collection.minter,
-  creator: collection.creator,
-  description: collection.description,
-  image: collection.image,
-  externalLink: collection.externalLink,
-  royaltyAddress: collection.royaltyAddress,
-  royaltyFee: collection.royaltyFee,
-  maxNumToken: collection.maxNumToken,
-  perAddressLimit: collection.perAddressLimit,
-  startTime: collection.startTime,
-  unitPrice: collection.unitPrice,
-  unitDenom: collection.unitDenom,
-});
+export async function mapCollection(collection: Collection) {
+  const stats = await getCollectionStats(collection.address);
+
+  return {
+    address: collection.address,
+    createdHeight: collection.createdHeight,
+    name: collection.name,
+    symbol: collection.symbol,
+    mintContract: collection.mintContract,
+    marketContract: collection.marketContract,
+    minter: collection.minter,
+    creator: collection.creator,
+    description: collection.description,
+    image: collection.image,
+    externalLink: collection.externalLink,
+    royaltyAddress: collection.royaltyAddress,
+    royaltyFee: collection.royaltyFee,
+    maxNumToken: collection.maxNumToken,
+    perAddressLimit: collection.perAddressLimit,
+    startTime: collection.startTime,
+    unitPrice: collection.unitPrice,
+    unitDenom: collection.unitDenom,
+    ...stats
+  };
+}

--- a/packages/database/drizzle/schema/transactionEventAttribute.ts
+++ b/packages/database/drizzle/schema/transactionEventAttribute.ts
@@ -5,7 +5,6 @@ import {
   integer,
   index,
   text,
-  bigserial,
 } from "drizzle-orm/pg-core";
 import { transactionEvent } from "./transactionEvent";
 import { relations } from "drizzle-orm";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       database:
         specifier: workspace:*
         version: link:../../packages/database
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -74,10 +77,10 @@ importers:
         version: 3.1.0
       nodemon-webpack-plugin:
         specifier: ^4.8.2
-        version: 4.8.2(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
+        version: 4.8.2(webpack@5.91.0)
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.4)(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.4)(webpack@5.91.0)
       webpack:
         specifier: ^5.91.0
         version: 5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)
@@ -189,13 +192,13 @@ importers:
         version: 3.1.0
       nodemon-webpack-plugin:
         specifier: ^4.8.2
-        version: 4.8.2(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
+        version: 4.8.2(webpack@5.91.0)
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.4.4)(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
+        version: 9.5.1(typescript@5.4.4)(webpack@5.91.0)
       webpack:
         specifier: ^5.91.0
-        version: 5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)
+        version: 5.91.0(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.91.0)
@@ -935,9 +938,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -1252,6 +1257,7 @@ packages:
   '@humanwhocodes/config-array@0.12.3':
     resolution: {integrity: sha512-jsNnTBlMWuTpDkeE3on7+dWJi0D6fdDfeANj/w7MpS8ztROCoLvIO2nG0CcFj+E4k8j4QrSTh4Oryi3i2G669g==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1259,6 +1265,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -2492,6 +2499,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -2614,6 +2622,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3486,6 +3495,7 @@ packages:
 
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   run-async@2.4.1:
@@ -5581,17 +5591,17 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.91.0)':
     dependencies:
       webpack: 5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0)':
     dependencies:
       webpack: 5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.91.0)':
     dependencies:
       webpack: 5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
@@ -7391,7 +7401,7 @@ snapshots:
 
   node-releases@2.0.14: {}
 
-  nodemon-webpack-plugin@4.8.2(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)):
+  nodemon-webpack-plugin@4.8.2(webpack@5.91.0):
     dependencies:
       '@types/nodemon': 1.19.6
       nodemon: 3.0.1
@@ -7941,7 +7951,7 @@ snapshots:
     dependencies:
       rimraf: 2.6.3
 
-  terser-webpack-plugin@5.3.10(esbuild@0.19.12)(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.10(esbuild@0.19.12)(webpack@5.91.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -7951,6 +7961,15 @@ snapshots:
       webpack: 5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.19.12
+
+  terser-webpack-plugin@5.3.10(webpack@5.91.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.30.3
+      webpack: 5.91.0(webpack-cli@5.1.4)
 
   terser@5.30.3:
     dependencies:
@@ -8005,7 +8024,7 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-loader@9.5.1(typescript@5.4.4)(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4)):
+  ts-loader@9.5.1(typescript@5.4.4)(webpack@5.91.0):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.16.0
@@ -8144,9 +8163,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.91.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.91.0))(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.91.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.91.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.91.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -8191,7 +8210,40 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.19.12)(webpack@5.91.0(esbuild@0.19.12)(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.10(esbuild@0.19.12)(webpack@5.91.0)
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack@5.91.0)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.91.0(webpack-cli@5.1.4):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.11.3
+      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      browserslist: 4.23.0
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.16.0
+      es-module-lexer: 1.5.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(webpack@5.91.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
Added the following stats to all endpoints returning collections
- NFT Count
- Unique owner count
- Floor price
- Sale count and volume as of now, 24h ago, 7d ago and 30d ago
- Listed token count