### PR TITLE
Add percentage change to endpoints

### DIFF
--- a/apps/api/src/routes/v1/collections/collectionById.ts
+++ b/apps/api/src/routes/v1/collections/collectionById.ts
@@ -43,25 +43,34 @@ const route = createRoute({
             nftCount: z.number(),
             uniqueOwnerCount: z.number(),
             floorPrice: z.string().nullable(),
-            saleCount: z.number(),
-            saleVolume: z.object({
+            totalSaleCount: z.number(),
+            totalSaleVolume: z.object({
               upasg: z.string().nullable(),
               usd: z.string().nullable()
             }),
-            saleCount24hAgo: z.number(),
-            saleVolume24hAgo: z.object({
+            saleCount24h: z.number(),
+            saleCount24hChangePercentage: z.number(),
+            saleVolume24h: z.object({
               upasg: z.string().nullable(),
-              usd: z.string().nullable()
+              upasgChangePercentage: z.number().nullable(),
+              usd: z.string().nullable(),
+              usdChangePercentage: z.number().nullable()
             }),
-            saleCount7dAgo: z.number(),
-            saleVolume7dAgo: z.object({
+            saleCount7d: z.number(),
+            saleCount7dChangePercentage: z.number(),
+            saleVolume7d: z.object({
               upasg: z.string().nullable(),
-              usd: z.string().nullable()
+              upasgChangePercentage: z.number().nullable(),
+              usd: z.string().nullable(),
+              usdChangePercentage: z.number().nullable()
             }),
-            saleCount30dAgo: z.number(),
-            saleVolume30dAgo: z.object({
+            saleCount30d: z.number(),
+            saleCount30dChangePercentage: z.number(),
+            saleVolume30d: z.object({
               upasg: z.string().nullable(),
-              usd: z.string().nullable()
+              upasgChangePercentage: z.number().nullable(),
+              usd: z.string().nullable(),
+              usdChangePercentage: z.number().nullable()
             }),
             listedTokenCount: z.number()
           })

--- a/apps/api/src/routes/v1/collections/collections.ts
+++ b/apps/api/src/routes/v1/collections/collections.ts
@@ -43,25 +43,34 @@ const route = createRoute({
                 nftCount: z.number(),
                 uniqueOwnerCount: z.number(),
                 floorPrice: z.string().nullable(),
-                saleCount: z.number(),
-                saleVolume: z.object({
+                totalSaleCount: z.number(),
+                totalSaleVolume: z.object({
                   upasg: z.string().nullable(),
                   usd: z.string().nullable()
                 }),
-                saleCount24hAgo: z.number(),
-                saleVolume24hAgo: z.object({
+                saleCount24h: z.number(),
+                saleCount24hChangePercentage: z.number(),
+                saleVolume24h: z.object({
                   upasg: z.string().nullable(),
-                  usd: z.string().nullable()
+                  upasgChangePercentage: z.number().nullable(),
+                  usd: z.string().nullable(),
+                  usdChangePercentage: z.number().nullable()
                 }),
-                saleCount7dAgo: z.number(),
-                saleVolume7dAgo: z.object({
+                saleCount7d: z.number(),
+                saleCount7dChangePercentage: z.number(),
+                saleVolume7d: z.object({
                   upasg: z.string().nullable(),
-                  usd: z.string().nullable()
+                  upasgChangePercentage: z.number().nullable(),
+                  usd: z.string().nullable(),
+                  usdChangePercentage: z.number().nullable()
                 }),
-                saleCount30dAgo: z.number(),
-                saleVolume30dAgo: z.object({
+                saleCount30d: z.number(),
+                saleCount30dChangePercentage: z.number(),
+                saleVolume30d: z.object({
                   upasg: z.string().nullable(),
-                  usd: z.string().nullable()
+                  upasgChangePercentage: z.number().nullable(),
+                  usd: z.string().nullable(),
+                  usdChangePercentage: z.number().nullable()
                 }),
                 listedTokenCount: z.number()
               })

--- a/apps/api/src/routes/v1/ecosystems/ecosystems.ts
+++ b/apps/api/src/routes/v1/ecosystems/ecosystems.ts
@@ -39,25 +39,34 @@ const route = createRoute({
                     nftCount: z.number(),
                     uniqueOwnerCount: z.number(),
                     floorPrice: z.string().nullable(),
-                    saleCount: z.number(),
-                    saleVolume: z.object({
+                    totalSaleCount: z.number(),
+                    totalSaleVolume: z.object({
                       upasg: z.string().nullable(),
                       usd: z.string().nullable()
                     }),
-                    saleCount24hAgo: z.number(),
-                    saleVolume24hAgo: z.object({
+                    saleCount24h: z.number(),
+                    saleCount24hChangePercentage: z.number(),
+                    saleVolume24h: z.object({
                       upasg: z.string().nullable(),
-                      usd: z.string().nullable()
+                      upasgChangePercentage: z.number().nullable(),
+                      usd: z.string().nullable(),
+                      usdChangePercentage: z.number().nullable()
                     }),
-                    saleCount7dAgo: z.number(),
-                    saleVolume7dAgo: z.object({
+                    saleCount7d: z.number(),
+                    saleCount7dChangePercentage: z.number(),
+                    saleVolume7d: z.object({
                       upasg: z.string().nullable(),
-                      usd: z.string().nullable()
+                      upasgChangePercentage: z.number().nullable(),
+                      usd: z.string().nullable(),
+                      usdChangePercentage: z.number().nullable()
                     }),
-                    saleCount30dAgo: z.number(),
-                    saleVolume30dAgo: z.object({
+                    saleCount30d: z.number(),
+                    saleCount30dChangePercentage: z.number(),
+                    saleVolume30d: z.object({
                       upasg: z.string().nullable(),
-                      usd: z.string().nullable()
+                      upasgChangePercentage: z.number().nullable(),
+                      usd: z.string().nullable(),
+                      usdChangePercentage: z.number().nullable()
                     }),
                     listedTokenCount: z.number()
                   })

--- a/apps/api/src/services/collection.service.ts
+++ b/apps/api/src/services/collection.service.ts
@@ -1,26 +1,13 @@
-import { block, day, db, eq, nft, nftListing, nftSale, and, lte, min, sql, sum, count, countDistinct, gte, nftToTrait, nftTrait } from "database";
-import { subHours, subDays } from "date-fns";
+import { block, day, db, eq, nft, nftListing, nftSale, and, lte, min, sql, sum, count, countDistinct, gte, nftToTrait, nftTrait, isNull, desc } from "database";
 import { TraitStats, GetTraitsOptions } from "@src/types/collection";
 import { udenomToDenom } from "@src/utils/math";
 
 export async function getCollectionStats(collectionAddress: string) {
-  const [
-    nftCount,
-    uniqueOwnerCount,
-    floorPrice,
-    { saleCount, saleVolume },
-    { saleCount: saleCount24hAgo, saleVolume: saleVolume24hAgo },
-    { saleCount: saleCount7dAgo, saleVolume: saleVolume7dAgo },
-    { saleCount: saleCount30dAgo, saleVolume: saleVolume30dAgo },
-    listedTokenCount
-  ] = await Promise.all([
+  const [nftCount, uniqueOwnerCount, floorPrice, saleAndVolumeStats, listedTokenCount] = await Promise.all([
     getNftCount(collectionAddress),
     getUniqueOwnerCount(collectionAddress),
     getFloorPrice(collectionAddress),
-    getSaleAndVolumeAtDate(collectionAddress),
-    getSaleAndVolumeAtDate(collectionAddress, subHours(new Date(), 24)),
-    getSaleAndVolumeAtDate(collectionAddress, subDays(new Date(), 7)),
-    getSaleAndVolumeAtDate(collectionAddress, subDays(new Date(), 30)),
+    getSaleAndVolumeStats(collectionAddress),
     getListedTokenCount(collectionAddress)
   ]);
 
@@ -28,14 +15,7 @@ export async function getCollectionStats(collectionAddress: string) {
     nftCount,
     uniqueOwnerCount,
     floorPrice,
-    saleCount,
-    saleVolume,
-    saleCount24hAgo,
-    saleVolume24hAgo,
-    saleCount7dAgo,
-    saleVolume7dAgo,
-    saleCount30dAgo,
-    saleVolume30dAgo,
+    ...saleAndVolumeStats,
     listedTokenCount
   };
 }
@@ -45,7 +25,7 @@ async function getFloorPrice(collectionAddress: string) {
     .select({ floorPrice: min(nftListing.forSalePrice) })
     .from(nftListing)
     .innerJoin(nft, eq(nftListing.nft, nft.id))
-    .where(eq(nft.collection, collectionAddress));
+    .where(and(isNull(nftListing.unlistedBlockHeight), eq(nft.collection, collectionAddress)));
 
   return floorPrice;
 }
@@ -61,7 +41,7 @@ async function getListedTokenCount(collectionAddress: string) {
     .select({ listedTokenCount: count() })
     .from(nftListing)
     .innerJoin(nft, eq(nftListing.nft, nft.id))
-    .where(eq(nft.collection, collectionAddress));
+    .where(and(isNull(nftListing.unlistedBlockHeight), eq(nft.collection, collectionAddress)));
 
   return listedTokenCount;
 }
@@ -75,16 +55,83 @@ async function getUniqueOwnerCount(collectionAddress: string) {
   return uniqueOwnerCount;
 }
 
-async function getSaleAndVolumeAtDate(collectionAddress: string, date?: Date) {
-  const [{ saleCount, saleVolumeUPasg, saleVolumeUSD }] = await db
-    .select({ saleCount: count(), saleVolumeUPasg: sum(nftSale.salePrice), saleVolumeUSD: sum(sql`${nftSale.salePrice} * ${day.tokenPrice} / 1000000`) })
+async function getSaleAndVolumeStats(collectionAddress: string | undefined) {
+  const lastProcessedBlock = await db.query.block.findFirst({ where: eq(block.isProcessed, true), orderBy: desc(block.height) });
+
+  const lastProcessedDate = lastProcessedBlock.datetime.toISOString();
+
+  const [results] = await db
+    .select({
+      totalSaleCount: count(),
+      totalSaleVolumeUPasg: sum(nftSale.salePrice),
+      totalSaleVolumeUSD: sum(sql`${nftSale.salePrice} * ${day.tokenPrice} / 1000000`),
+      saleCount24h: sql`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp::timestamp - INTERVAL '24 hours')`.mapWith(Number),
+      saleCount7d: sql`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '7 days')`.mapWith(Number),
+      saleCount30d: sql`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '30 days')`.mapWith(Number),
+      saleVolume24hUPasg: sql<string>`SUM(${nftSale.salePrice}) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '24 hours')`,
+      saleVolume7dUPasg: sql<string>`SUM(${nftSale.salePrice}) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '7 days')`,
+      saleVolume30dUPasg: sql<string>`SUM(${nftSale.salePrice}) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '30 days')`,
+      saleVolume24hUSD: sql<number>`SUM(${nftSale.salePrice} * ${day.tokenPrice} / 1000000) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '24 hours')`,
+      saleVolume7dUSD: sql<number>`SUM(${nftSale.salePrice} * ${day.tokenPrice} / 1000000) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '7 days')`,
+      saleVolume30dUSD: sql<number>`SUM(${nftSale.salePrice} * ${day.tokenPrice} / 1000000) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '30 days')`,
+      saleCount24hComparison:
+        sql`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '48 hours' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '24 hours')`.mapWith(
+          Number
+        ),
+      saleCount7dComparison:
+        sql`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '14 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '7 days')`.mapWith(
+          Number
+        ),
+      saleCount30dComparison:
+        sql`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '60 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '30 days')`.mapWith(
+          Number
+        ),
+      saleVolume24hUPasgComparison: sql<string>`SUM(${nftSale.salePrice}) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '48 hours' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '24 hours')`,
+      saleVolume7dUPasgComparison: sql<string>`SUM(${nftSale.salePrice}) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '14 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '7 days')`,
+      saleVolume30dUPasgComparison: sql<string>`SUM(${nftSale.salePrice}) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '60 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '30 days')`,
+      saleVolume24hUSDComparison: sql<number>`SUM(${nftSale.salePrice} * ${day.tokenPrice} / 1000000) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '48 hours' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '24 hours')`,
+      saleVolume7dUSDComparison: sql<number>`SUM(${nftSale.salePrice} * ${day.tokenPrice} / 1000000) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '14 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '7 days')`,
+      saleVolume30dUSDComparison: sql<number>`SUM(${nftSale.salePrice} * ${day.tokenPrice} / 1000000) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '60 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '30 days')`
+    })
     .from(nftSale)
     .innerJoin(nft, eq(nftSale.nft, nft.id))
     .innerJoin(block, eq(nftSale.saleBlockHeight, block.height))
     .innerJoin(day, eq(block.dayId, day.id))
-    .where(and(eq(nft.collection, collectionAddress), lte(block.datetime, date).if(date)));
+    .where(and(eq(nft.collection, collectionAddress)));
 
-  return { saleCount, saleVolume: { upasg: saleVolumeUPasg, usd: saleVolumeUSD } };
+  return {
+    totalSaleCount: results.totalSaleCount,
+    totalSaleVolume: { upasg: results.totalSaleVolumeUPasg, usd: results.totalSaleVolumeUSD },
+    saleCount24h: results.saleCount24h,
+    saleCount24hChangePercentage: calculateChangePercentage(results.saleCount24h, results.saleCount24hComparison),
+    saleVolume24h: {
+      upasg: results.saleVolume24hUPasg,
+      upasgChangePercentage: calculateChangePercentage(parseFloat(results.saleVolume24hUPasg), parseFloat(results.saleVolume24hUPasgComparison)),
+      usd: results.saleVolume24hUSD?.toString(),
+      usdChangePercentage: calculateChangePercentage(results.saleVolume24hUSD, results.saleVolume24hUSDComparison)
+    },
+    saleCount7d: results.saleCount7d,
+    saleCount7dChangePercentage: calculateChangePercentage(results.saleCount7d, results.saleCount7dComparison),
+    saleVolume7d: {
+      upasg: results.saleVolume7dUPasg,
+      upasgChangePercentage: calculateChangePercentage(parseFloat(results.saleVolume7dUPasg), parseFloat(results.saleVolume7dUPasgComparison)),
+      usd: results.saleVolume7dUSD?.toString(),
+      usdChangePercentage: calculateChangePercentage(results.saleVolume7dUSD, results.saleVolume7dUSDComparison)
+    },
+    saleCount30d: results.saleCount30d,
+    saleCount30dChangePercentage: calculateChangePercentage(results.saleCount30d, results.saleCount30dComparison),
+    saleVolume30d: {
+      upasg: results.saleVolume30dUPasg,
+      upasgChangePercentage: calculateChangePercentage(parseFloat(results.saleVolume30dUPasg), parseFloat(results.saleVolume30dUPasgComparison)),
+      usd: results.saleVolume30dUSD?.toString(),
+      usdChangePercentage: calculateChangePercentage(results.saleVolume30dUSD, results.saleVolume30dUSDComparison)
+    }
+  };
+}
+
+function calculateChangePercentage(current: number, previous: number) {
+  if (previous === 0) return null;
+  return ((current - previous) / previous) * 100;
 }
 
 export async function getCollectionTraits(address: string, options: GetTraitsOptions): Promise<TraitStats[]> {
@@ -112,7 +159,7 @@ export async function getCollectionTraits(address: string, options: GetTraitsOpt
       id: true,
       traitType: true,
       traitValue: true
-    },
+    }
   });
 
   // Then, get sales data in a separate query
@@ -122,7 +169,7 @@ export async function getCollectionTraits(address: string, options: GetTraitsOpt
       salePrice: nftSale.salePrice,
       saleDenom: nftSale.saleDenom,
       datetime: block.datetime,
-      tokenPrice: day.tokenPrice,
+      tokenPrice: day.tokenPrice
     })
     .from(nftSale)
     .innerJoin(nft, eq(nft.id, nftSale.nft))
@@ -130,15 +177,7 @@ export async function getCollectionTraits(address: string, options: GetTraitsOpt
     .innerJoin(nftTrait, eq(nftTrait.id, nftToTrait.traitId))
     .innerJoin(block, eq(block.height, nftSale.saleBlockHeight))
     .innerJoin(day, eq(day.id, block.dayId))
-    .where(
-      and(
-        eq(nftTrait.collection, address),
-        options.traitType
-          ? eq(nftTrait.traitType, options.traitType)
-          : undefined,
-        ...dateFilters
-      )
-    );
+    .where(and(eq(nftTrait.collection, address), options.traitType ? eq(nftTrait.traitType, options.traitType) : undefined, ...dateFilters));
 
   // Create a map to store sales data by trait
   const traitSalesMap = new Map<
@@ -170,7 +209,7 @@ export async function getCollectionTraits(address: string, options: GetTraitsOpt
         volumeUsd: 0,
         volumePasg: 0,
         averagePriceUsd: 0,
-        averagePricePasg: 0,
+        averagePricePasg: 0
       });
     }
 
@@ -182,7 +221,7 @@ export async function getCollectionTraits(address: string, options: GetTraitsOpt
       data.sales.push({
         priceUsd,
         pricePasg,
-        datetime: sale.datetime,
+        datetime: sale.datetime
       });
       data.totalSales++;
       data.volumeUsd += priceUsd;
@@ -219,9 +258,7 @@ export async function getCollectionTraits(address: string, options: GetTraitsOpt
 
     if (salesData) {
       const now = new Date();
-      const sales = salesData.sales.sort(
-        (a, b) => b.datetime.getTime() - a.datetime.getTime()
-      );
+      const sales = salesData.sales.sort((a, b) => b.datetime.getTime() - a.datetime.getTime());
 
       stats.metrics.totalSales = salesData.totalSales;
       stats.metrics.volumeUsd = salesData.volumeUsd;
@@ -249,51 +286,33 @@ function sortTraitStats(stats: TraitStats[], sortBy?: "top" | "trending"): Trait
   return stats;
 }
 
-function calculateUsdPrice(
-  amount: string,
-  tokenPrice: number | null
-): number | null {
+function calculateUsdPrice(amount: string, tokenPrice: number | null): number | null {
   if (!amount || !tokenPrice) {
     return null;
   }
   return (parseFloat(amount) * tokenPrice) / 1_000_000;
 }
 
-function calculateVolumeChange(
-  sales: { priceUsd: number; datetime: Date }[],
-  now: Date,
-  days: number
-): number | null {
+function calculateVolumeChange(sales: { priceUsd: number; datetime: Date }[], now: Date, days: number): number | null {
   // Convert days to milliseconds
   const periodLength = days * 24 * 60 * 60 * 1000;
 
   // Calculate period boundaries
   const currentPeriodStart = new Date(now.getTime() - periodLength);
-  const previousPeriodStart = new Date(
-    currentPeriodStart.getTime() - periodLength
-  );
+  const previousPeriodStart = new Date(currentPeriodStart.getTime() - periodLength);
 
   // Calculate current period volume (last X days)
-  const currentPeriodVolume = sales
-    .filter(
-      (sale) => sale.datetime >= currentPeriodStart && sale.datetime <= now
-    )
-    .reduce((sum, sale) => sum + sale.priceUsd, 0);
+  const currentPeriodVolume = sales.filter((sale) => sale.datetime >= currentPeriodStart && sale.datetime <= now).reduce((sum, sale) => sum + sale.priceUsd, 0);
 
   // Calculate previous period volume (X days before that)
   const previousPeriodVolume = sales
-    .filter(
-      (sale) =>
-        sale.datetime >= previousPeriodStart &&
-        sale.datetime < currentPeriodStart
-    )
+    .filter((sale) => sale.datetime >= previousPeriodStart && sale.datetime < currentPeriodStart)
     .reduce((sum, sale) => sum + sale.priceUsd, 0);
 
   // If there were no sales in the previous period, return null
   if (previousPeriodVolume === 0) return null;
 
   // Calculate percent change
-  const percentChange =
-    ((currentPeriodVolume - previousPeriodVolume) / previousPeriodVolume) * 100;
+  const percentChange = ((currentPeriodVolume - previousPeriodVolume) / previousPeriodVolume) * 100;
   return Math.round(percentChange * 100) / 100; // Round to 2 decimal places
 }

--- a/apps/api/src/services/nft.service.ts
+++ b/apps/api/src/services/nft.service.ts
@@ -1,26 +1,17 @@
-import {
-  asc,
-  block as blockTable,
-  day as dayTable,
-  db,
-  eq,
-  nftBid,
-  nftListing,
-  nftSale,
-} from "database";
+import { and, asc, block as blockTable, day as dayTable, db, eq, isNull, nftBid, nftListing, nftSale } from "database";
 
-export async function getNftListings(nftId: string) {
+export async function getNftActiveListings(nftId: string) {
   const listings = await db
     .select()
     .from(nftListing)
     .leftJoin(blockTable, eq(nftListing.forSaleBlockHeight, blockTable.height))
     .innerJoin(dayTable, eq(blockTable.dayId, dayTable.id))
-    .where(eq(nftListing.nft, nftId))
+    .where(and(eq(nftListing.nft, nftId), isNull(nftListing.unlistedBlockHeight)))
     .orderBy(asc(nftListing.forSaleBlockHeight));
 
   return listings.map((x) => ({
     ...x.nft_listing,
-    block: { ...x.block, day: x.day },
+    block: { ...x.block, day: x.day }
   }));
 }
 
@@ -35,7 +26,7 @@ export async function getNftBids(nftId: string) {
 
   return bids.map((x) => ({
     ...x.nft_bid,
-    block: { ...x.block, day: x.day },
+    block: { ...x.block, day: x.day }
   }));
 }
 
@@ -50,6 +41,6 @@ export async function getNftSales(nftId: string) {
 
   return sales.map((x) => ({
     ...x.nft_sale,
-    block: { ...x.block, day: x.day },
+    block: { ...x.block, day: x.day }
   }));
 }


### PR DESCRIPTION
- Return volume and sale stats for specific periods (24h,7d,30d) and added percentage change relative to previous period
- Change `listedTokenCount` and `floorPrice` to only include active listings