### PR TITLE
Add nft stats & sorting

### DIFF
--- a/apps/api/src/routes/v1/collections/nfts.ts
+++ b/apps/api/src/routes/v1/collections/nfts.ts
@@ -1,13 +1,9 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { getNftsWithStats, nftSortOptions } from "@src/services/nft.service";
 import { OpenAPI_ExampleCollection } from "@src/utils/constants";
-import { and, asc, count, db, desc, eq, isNotNull, isNull, nft, nftListing } from "database";
+import { db, eq } from "database";
 
 const maxLimit = 100;
-
-const sortOptions = {
-  priceAsc: asc(nftListing.forSalePrice),
-  priceDesc: desc(nftListing.forSalePrice)
-};
 
 const route = createRoute({
   method: "get",
@@ -30,18 +26,18 @@ const route = createRoute({
           description: "Filter by sale type",
           enum: ["LIVE_AUCTION", "FIXED_PRICE", "NOT_FOR_SALE"]
         }),
-      sort: z
-        .string()
-        .optional()
-        .openapi({
-          description: "Sort order",
-          enum: Object.keys(sortOptions)
-        })
+      sort: z.string().optional().openapi({
+        description: "Sort order",
+        enum: nftSortOptions
+      })
     })
   },
   responses: {
     404: {
       description: "Collection not found"
+    },
+    400: {
+      description: "Invalid parameter"
     },
     200: {
       description: "List of nfts",
@@ -59,7 +55,14 @@ const route = createRoute({
                 mintDenom: z.string(),
                 saleType: z.enum(["LIVE_AUCTION", "FIXED_PRICE", "NOT_FOR_SALE"]),
                 listedPrice: z.number().nullable(),
-                listedDenom: z.string().nullable()
+                listedDenom: z.string().nullable(),
+                saleCount: z.number(),
+                saleCount24h: z.number(),
+                saleCount7d: z.number(),
+                saleCount30d: z.number(),
+                saleCount24hPercentageChange: z.number().nullable(),
+                saleCount7dPercentageChange: z.number().nullable(),
+                saleCount30dPercentageChange: z.number().nullable()
               })
             ),
             pagination: z.object({
@@ -77,7 +80,11 @@ export default new OpenAPIHono().openapi(route, async (c) => {
   const skip = parseInt(c.req.valid("query").skip);
   const limit = Math.min(maxLimit, parseInt(c.req.valid("query").limit));
   const saleType = c.req.valid("query").saleType;
-  const sort = sortOptions[c.req.valid("query").sort] || asc(nft.tokenId);
+  const sort = c.req.valid("query").sort;
+
+  if (sort && !nftSortOptions.includes(sort)) {
+    return c.text("Invalid sort option, valid options are: " + nftSortOptions.join(","), 400);
+  }
 
   const collection = await db.query.collection.findFirst({
     where: (table) => eq(table.address, collectionAddress)
@@ -87,34 +94,16 @@ export default new OpenAPIHono().openapi(route, async (c) => {
     return c.text("Collection not found", 404);
   }
 
-  const [{ count: totalCount }] = await db
-    .select({ count: count() })
-    .from(nft)
-    .where(
-      and(
-        eq(nft.collection, collectionAddress),
-        isNotNull(nft.activeListingId).if(saleType === "FIXED_PRICE"),
-        isNull(nft.activeListingId).if(saleType === "NOT_FOR_SALE")
-      )
-    );
-
-  const nfts = await db
-    .select()
-    .from(nft)
-    .where(
-      and(
-        eq(nft.collection, collectionAddress),
-        isNotNull(nft.activeListingId).if(saleType === "FIXED_PRICE"),
-        isNull(nft.activeListingId).if(saleType === "NOT_FOR_SALE")
-      )
-    )
-    .leftJoin(nftListing, eq(nftListing.id, nft.activeListingId))
-    .offset(skip)
-    .limit(limit)
-    .orderBy(sort);
+  const { nfts, totalCount } = await getNftsWithStats({
+    collectionAddress,
+    saleType,
+    sort,
+    skip,
+    limit
+  });
 
   return c.json({
-    nfts: nfts.map(({ nft, nft_listing: activeListing }) => ({
+    nfts: nfts.map((nft) => ({
       tokenId: nft.tokenId,
       owner: nft.owner,
       metadata: nft.metadata,
@@ -122,9 +111,16 @@ export default new OpenAPIHono().openapi(route, async (c) => {
       mintedOnBlockHeight: nft.mintedOnBlockHeight,
       mintPrice: nft.mintPrice,
       mintDenom: nft.mintDenom,
-      saleType: activeListing ? "FIXED_PRICE" : "NOT_FOR_SALE",
-      listedPrice: activeListing?.forSalePrice || null,
-      listedDenom: activeListing?.forSaleDenom || null
+      saleType: nft.forSalePrice ? "FIXED_PRICE" : "NOT_FOR_SALE",
+      listedPrice: nft.forSalePrice || null,
+      listedDenom: nft.forSaleDenom || null,
+      saleCount: parseInt(nft.saleCount),
+      saleCount24h: parseInt(nft.saleCount24h),
+      saleCount7d: parseInt(nft.saleCount7d),
+      saleCount30d: parseInt(nft.saleCount30d),
+      saleCount24hPercentageChange: nft.saleCount24hPercentageChange,
+      saleCount7dPercentageChange: nft.saleCount7dPercentageChange,
+      saleCount30dPercentageChange: nft.saleCount30dPercentageChange
     })),
     pagination: {
       total: totalCount

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,12 +1,13 @@
 import collections from "./collections/collections";
 import collectionById from "./collections/collectionById";
-import nfts from "./collections/nfts";
-import nftById from "./collections/nftById";
+import collectionNfts from "./collections/nfts";
+import collectionNftById from "./collections/nftById";
 import nftsByOwner from "./accounts/nfts";
 import orders from "./accounts/orders";
+import nfts from "./nfts/nfts";
 import ecosystems from "./ecosystems/ecosystems";
 import collectionTraits from "./collections/collectionTraits";
 import statsSummary from "./stats/summary";
 import graph from "./stats/graph";
 
-export default [collections, collectionById, nfts, nftById, nftsByOwner, orders, ecosystems, collectionTraits, statsSummary, graph];
+export default [collections, collectionById, collectionNfts, collectionNftById, nftsByOwner, orders, nfts, ecosystems, collectionTraits, statsSummary, graph];

--- a/apps/api/src/routes/v1/nfts/nfts.ts
+++ b/apps/api/src/routes/v1/nfts/nfts.ts
@@ -1,0 +1,109 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { getNftsWithStats, nftSortOptions } from "@src/services/nft.service";
+
+const maxLimit = 100;
+
+const route = createRoute({
+  method: "get",
+  path: "/nfts",
+  summary: "Get a list of NFTs.",
+  request: {
+    query: z.object({
+      skip: z.string().optional().default("0").openapi({ description: "NFTs to skip" }),
+      limit: z.string().optional().default(maxLimit.toString()).openapi({ description: "NFTs to return", maximum: maxLimit }),
+      saleType: z
+        .string()
+        .optional()
+        .openapi({
+          description: "Filter by sale type",
+          enum: ["LIVE_AUCTION", "FIXED_PRICE", "NOT_FOR_SALE"]
+        }),
+      sort: z.string().optional().openapi({
+        description: "Sort order",
+        enum: nftSortOptions
+      })
+    })
+  },
+  responses: {
+    400: {
+      description: "Invalid parameter"
+    },
+    200: {
+      description: "List of nfts",
+      content: {
+        "application/json": {
+          schema: z.object({
+            nfts: z.array(
+              z.object({
+                tokenId: z.string(),
+                owner: z.string(),
+                metadata: z.unknown({ description: "JSON Metadata" }),
+                createdOnBlockHeight: z.number(),
+                mintedOnBlockHeight: z.number(),
+                mintPrice: z.number(),
+                mintDenom: z.string(),
+                saleType: z.enum(["LIVE_AUCTION", "FIXED_PRICE", "NOT_FOR_SALE"]),
+                listedPrice: z.number().nullable(),
+                listedDenom: z.string().nullable(),
+                saleCount: z.number(),
+                saleCount24h: z.number(),
+                saleCount7d: z.number(),
+                saleCount30d: z.number(),
+                saleCount24hPercentageChange: z.number().nullable(),
+                saleCount7dPercentageChange: z.number().nullable(),
+                saleCount30dPercentageChange: z.number().nullable()
+              })
+            ),
+            pagination: z.object({
+              total: z.number()
+            })
+          })
+        }
+      }
+    }
+  }
+});
+
+export default new OpenAPIHono().openapi(route, async (c) => {
+  const skip = parseInt(c.req.valid("query").skip);
+  const limit = Math.min(maxLimit, parseInt(c.req.valid("query").limit));
+  const saleType = c.req.valid("query").saleType;
+  const sort = c.req.valid("query").sort;
+
+  if (sort && !nftSortOptions.includes(sort)) {
+    return c.text("Invalid sort option, valid options are: " + nftSortOptions.join(","), 400);
+  }
+  console.time("getNftsWithStats");
+  const { nfts, totalCount } = await getNftsWithStats({
+    saleType,
+    sort,
+    skip,
+    limit
+  });
+  console.timeEnd("getNftsWithStats");
+
+  return c.json({
+    nfts: nfts.map((nft) => ({
+      tokenId: nft.tokenId,
+      owner: nft.owner,
+      metadata: nft.metadata,
+      createdOnBlockHeight: nft.createdOnBlockHeight,
+      mintedOnBlockHeight: nft.mintedOnBlockHeight,
+      mintPrice: nft.mintPrice,
+      mintDenom: nft.mintDenom,
+      saleType: nft.forSalePrice ? "FIXED_PRICE" : "NOT_FOR_SALE",
+      listedPrice: nft.forSalePrice || null,
+      listedDenom: nft.forSaleDenom || null,
+      saleCount: parseInt(nft.saleCount),
+      saleCount24h: parseInt(nft.saleCount24h),
+      saleCount7d: parseInt(nft.saleCount7d),
+      saleCount30d: parseInt(nft.saleCount30d),
+      saleCount24hPercentageChange: nft.saleCount24hPercentageChange,
+      saleCount7dPercentageChange: nft.saleCount7dPercentageChange,
+      saleCount30dPercentageChange: nft.saleCount30dPercentageChange
+    })),
+    pagination: {
+      total: totalCount
+    }
+  });
+});

--- a/apps/api/src/services/block.service.ts
+++ b/apps/api/src/services/block.service.ts
@@ -1,0 +1,6 @@
+import { block, db, desc, eq } from "database";
+
+export async function getLastProcessedISODate() {
+  const lastProcessedBlock = await db.query.block.findFirst({ where: eq(block.isProcessed, true), orderBy: desc(block.height) });
+  return lastProcessedBlock.datetime.toISOString();
+}

--- a/apps/api/src/services/collection.service.ts
+++ b/apps/api/src/services/collection.service.ts
@@ -1,6 +1,7 @@
 import { block, day, db, eq, nft, nftListing, nftSale, and, lte, min, sql, sum, count, countDistinct, gte, nftToTrait, nftTrait, isNull, desc } from "database";
 import { TraitStats, GetTraitsOptions } from "@src/types/collection";
 import { udenomToDenom } from "@src/utils/math";
+import { getLastProcessedISODate } from "./block.service";
 
 export async function getCollectionStats(collectionAddress: string) {
   const [nftCount, uniqueOwnerCount, floorPrice, saleAndVolumeStats, listedTokenCount] = await Promise.all([
@@ -56,9 +57,7 @@ async function getUniqueOwnerCount(collectionAddress: string) {
 }
 
 async function getSaleAndVolumeStats(collectionAddress: string | undefined) {
-  const lastProcessedBlock = await db.query.block.findFirst({ where: eq(block.isProcessed, true), orderBy: desc(block.height) });
-
-  const lastProcessedDate = lastProcessedBlock.datetime.toISOString();
+  const lastProcessedDate = await getLastProcessedISODate();
 
   const [results] = await db
     .select({

--- a/apps/api/src/services/nft.service.ts
+++ b/apps/api/src/services/nft.service.ts
@@ -1,4 +1,5 @@
-import { and, asc, block as blockTable, day as dayTable, db, eq, isNull, nftBid, nftListing, nftSale } from "database";
+import { and, asc, block, block as blockTable, count, day as dayTable, db, desc, eq, isNotNull, isNull, nft, nftBid, nftListing, nftSale, sql } from "database";
+import { getLastProcessedISODate } from "./block.service";
 
 export async function getNftActiveListings(nftId: string) {
   const listings = await db
@@ -43,4 +44,138 @@ export async function getNftSales(nftId: string) {
     ...x.nft_sale,
     block: { ...x.block, day: x.day }
   }));
+}
+
+export const nftSortOptions = [
+  "priceAsc",
+  "priceDesc",
+  "saleCountAsc",
+  "saleCountDesc",
+  "saleCount24hAsc",
+  "saleCount24hDesc",
+  "saleCount7dAsc",
+  "saleCount7dDesc",
+  "saleCount30dAsc",
+  "saleCount30dDesc",
+  "saleCount24hPercentageChangeAsc",
+  "saleCount24hPercentageChangeDesc",
+  "saleCount7dPercentageChangeAsc",
+  "saleCount7dPercentageChangeDesc",
+  "saleCount30dPercentageChangeAsc",
+  "saleCount30dPercentageChangeDesc"
+];
+
+export async function getNftsWithStats({
+  collectionAddress,
+  saleType,
+  sort,
+  skip,
+  limit
+}: {
+  collectionAddress?: string;
+  saleType?: string;
+  sort: string;
+  skip: number;
+  limit: number;
+}) {
+  const nftFilterFn = and(
+    eq(nft.collection, collectionAddress).if(collectionAddress),
+    isNotNull(nft.activeListingId).if(saleType === "FIXED_PRICE"),
+    isNull(nft.activeListingId).if(saleType === "NOT_FOR_SALE")
+  );
+
+  const [{ count: totalCount }] = await db.select({ count: count() }).from(nft).where(nftFilterFn);
+
+  const lastProcessedDate = await getLastProcessedISODate();
+
+  const nftsDataSql = db.$with("nfts_data").as(
+    db
+      .select({
+        nftId: nftSale.nft,
+        saleCount: sql<string>`COUNT(*)`.as("sale_count"),
+        saleCount24h: sql<string>`COUNT(*) FILTER (WHERE ${block.datetime} > ${lastProcessedDate}::timestamp - INTERVAL '24 hours')`.as("sale_count_24h"),
+        saleCount7d: sql<string>`COUNT(*) FILTER (WHERE ${block.datetime} > ${lastProcessedDate}::timestamp - INTERVAL '7 days')`.as("sale_count_7d"),
+        saleCount30d: sql<string>`COUNT(*) FILTER (WHERE ${block.datetime} > ${lastProcessedDate}::timestamp - INTERVAL '30 days')`.as("sale_count_30d"),
+        saleCount24hComparison:
+          sql<string>`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '48 hours' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '24 hours')`.as(
+            "sale_count_24h_comparison"
+          ),
+        saleCount7dComparison:
+          sql<string>`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '14 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '7 days')`.as(
+            "sale_count_7d_comparison"
+          ),
+        saleCount30dComparison:
+          sql<string>`COUNT(*) FILTER (WHERE ${block.datetime} >= ${lastProcessedDate}::timestamp - INTERVAL '60 days' AND ${block.datetime} < ${lastProcessedDate}::timestamp - INTERVAL '30 days')`.as(
+            "sale_count_30d_comparison"
+          )
+      })
+      .from(nftSale)
+      .innerJoin(nft, eq(nft.id, nftSale.nft))
+      .innerJoin(block, eq(block.height, nftSale.saleBlockHeight))
+      .where(nftFilterFn)
+      .groupBy(nftSale.nft)
+  );
+
+  const nftsStatsSql = db.$with("nfts_stats").as(
+    db
+      .with(nftsDataSql)
+      .select({
+        tokenId: nft.tokenId,
+        owner: nft.owner,
+        metadata: nft.metadata,
+        createdOnBlockHeight: nft.createdOnBlockHeight,
+        mintedOnBlockHeight: nft.mintedOnBlockHeight,
+        mintPrice: nft.mintPrice,
+        mintDenom: nft.mintDenom,
+        forSalePrice: nftListing.forSalePrice,
+        forSaleDenom: nftListing.forSaleDenom,
+        saleCount: nftsDataSql.saleCount,
+        saleCount24h: nftsDataSql.saleCount24h,
+        saleCount7d: nftsDataSql.saleCount7d,
+        saleCount30d: nftsDataSql.saleCount30d,
+        saleCount24hPercentageChange:
+          sql`CASE WHEN ${nftsDataSql.saleCount24hComparison} = 0 THEN NULL ELSE ${nftsDataSql.saleCount24h} - ${nftsDataSql.saleCount24hComparison} / ${nftsDataSql.saleCount24hComparison} * 100 END`.as(
+            "sale_count_24h_percentage_change"
+          ),
+        saleCount7dPercentageChange:
+          sql`CASE WHEN ${nftsDataSql.saleCount7dComparison} = 0 THEN NULL ELSE ${nftsDataSql.saleCount7d} - ${nftsDataSql.saleCount7dComparison} / ${nftsDataSql.saleCount7dComparison} * 100 END`.as(
+            "sale_count_7d_percentage_change"
+          ),
+        saleCount30dPercentageChange:
+          sql`CASE WHEN ${nftsDataSql.saleCount30dComparison} = 0 THEN NULL ELSE ${nftsDataSql.saleCount30d} - ${nftsDataSql.saleCount30dComparison} / ${nftsDataSql.saleCount30dComparison} * 100 END`.as(
+            "sale_count_30d_percentage_change"
+          )
+      })
+      .from(nftsDataSql)
+      .innerJoin(nft, eq(nft.id, nftsDataSql.nftId))
+      .leftJoin(nftListing, eq(nftListing.id, nft.activeListingId))
+  );
+
+  const sortMapping = {
+    priceAsc: asc(nftsStatsSql.forSalePrice),
+    priceDesc: desc(nftsStatsSql.forSalePrice),
+    saleCountAsc: asc(nftsStatsSql.saleCount),
+    saleCountDesc: desc(nftsStatsSql.saleCount),
+    saleCount24hAsc: asc(nftsStatsSql.saleCount24h),
+    saleCount24hDesc: desc(nftsStatsSql.saleCount24h),
+    saleCount7dAsc: asc(nftsStatsSql.saleCount7d),
+    saleCount7dDesc: desc(nftsStatsSql.saleCount7d),
+    saleCount30dAsc: asc(nftsStatsSql.saleCount30d),
+    saleCount30dDesc: desc(nftsStatsSql.saleCount30d),
+    saleCount24hPercentageChangeAsc: asc(nftsStatsSql.saleCount24hPercentageChange),
+    saleCount24hPercentageChangeDesc: desc(nftsStatsSql.saleCount24hPercentageChange),
+    saleCount7dPercentageChangeAsc: asc(nftsStatsSql.saleCount7dPercentageChange),
+    saleCount7dPercentageChangeDesc: desc(nftsStatsSql.saleCount7dPercentageChange),
+    saleCount30dPercentageChangeAsc: asc(nftsStatsSql.saleCount30dPercentageChange),
+    saleCount30dPercentageChangeDesc: desc(nftsStatsSql.saleCount30dPercentageChange)
+  };
+
+  const sortFn = sortMapping[sort] || sortMapping.priceAsc;
+
+  const nfts = await db.with(nftsStatsSql).select().from(nftsStatsSql).orderBy(sortFn).offset(skip).limit(limit);
+
+  return {
+    nfts: nfts,
+    totalCount: totalCount
+  };
 }

--- a/packages/database/drizzle/schema/nft.ts
+++ b/packages/database/drizzle/schema/nft.ts
@@ -14,7 +14,7 @@ import { block } from "./block";
 import { nftBid } from "./nftBid";
 import { nftTransfer } from "./nftTransfer";
 import { nftListing } from "./nftListing";
-import { nftToTrait, nftTrait } from "./nftTrait";
+import { nftToTrait } from "./nftTrait";
 import { nftSale } from "./nftSale";
 
 export const nft = pgTable(

--- a/packages/database/drizzle/schema/nftSale.ts
+++ b/packages/database/drizzle/schema/nftSale.ts
@@ -1,26 +1,39 @@
 import { relations } from "drizzle-orm";
-import { pgTable, varchar, integer, uuid, numeric } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  varchar,
+  integer,
+  uuid,
+  numeric,
+  index,
+} from "drizzle-orm/pg-core";
 import { nft } from "./nft";
 import { block } from "./block";
 
-export const nftSale = pgTable("nft_sale", {
-  id: uuid("id").defaultRandom().primaryKey().notNull(),
-  previousOwner: varchar("previous_owner", { length: 255 }).notNull(),
-  newOwner: varchar("new_owner", { length: 255 }).notNull(),
-  nft: uuid("nft")
-    .references(() => nft.id)
-    .notNull(),
-  salePrice: numeric("sale_price").notNull(),
-  saleDenom: varchar("sale_denom", { length: 255 }).notNull(),
-  saleBlockHeight: integer("sale_block_height")
-    .references(() => block.height)
-    .notNull(),
-  marketFee: numeric("market_fee").notNull(),
-  marketFeeDenom: varchar("market_fee_denom").notNull(),
-  royaltyFee: numeric("royalty_fee").notNull(),
-  royaltyFeeDenom: varchar("royalty_fee_denom").notNull(),
-  royaltyFeeAddress: varchar("royalty_fee_address").notNull(),
-});
+export const nftSale = pgTable(
+  "nft_sale",
+  {
+    id: uuid("id").defaultRandom().primaryKey().notNull(),
+    previousOwner: varchar("previous_owner", { length: 255 }).notNull(),
+    newOwner: varchar("new_owner", { length: 255 }).notNull(),
+    nft: uuid("nft")
+      .references(() => nft.id)
+      .notNull(),
+    salePrice: numeric("sale_price").notNull(),
+    saleDenom: varchar("sale_denom", { length: 255 }).notNull(),
+    saleBlockHeight: integer("sale_block_height")
+      .references(() => block.height)
+      .notNull(),
+    marketFee: numeric("market_fee").notNull(),
+    marketFeeDenom: varchar("market_fee_denom").notNull(),
+    royaltyFee: numeric("royalty_fee").notNull(),
+    royaltyFeeDenom: varchar("royalty_fee_denom").notNull(),
+    royaltyFeeAddress: varchar("royalty_fee_address").notNull(),
+  },
+  (table) => ({
+    nft: index("nft_sale_nft").on(table.nft),
+  })
+);
 
 export const nftSaleRelations = relations(nftSale, ({ one }) => ({
   nft: one(nft, {


### PR DESCRIPTION
- Add sales metrics on the `/collections/{address}/nfts` endpoint and allow sorting on it
- Add `/nfts` endpoint to get ALL nfts and their sales metrics